### PR TITLE
feat: hit royale API endpoint and clean data to only show clan mate battles

### DIFF
--- a/prisma/dbml/schema.dbml
+++ b/prisma/dbml/schema.dbml
@@ -5,10 +5,14 @@
 Table battles {
   id Int [pk, increment]
   battleTime String [not null]
+  playerName String [not null]
   playerTag String [not null]
-  opponentTag String [not null]
+  playerDeck String[] [not null]
   playerCrowns Int [not null]
+  opponentName String [not null]
+  opponentTag String [not null]
+  opponentDeck String[] [not null]
   opponentCrowns Int [not null]
-  clanId String [not null]
-  win Boolean [not null]
+  clanName String [not null]
+  win Int [not null]
 }

--- a/prisma/migrations/20231104155412_update_table_shape/migration.sql
+++ b/prisma/migrations/20231104155412_update_table_shape/migration.sql
@@ -1,0 +1,19 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `clanId` on the `battles` table. All the data in the column will be lost.
+  - Added the required column `clanName` to the `battles` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `opponentName` to the `battles` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `playerName` to the `battles` table without a default value. This is not possible if the table is not empty.
+  - Changed the type of `win` on the `battles` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+
+*/
+-- AlterTable
+ALTER TABLE "battles" DROP COLUMN "clanId",
+ADD COLUMN     "clanName" TEXT NOT NULL,
+ADD COLUMN     "opponentDeck" TEXT[],
+ADD COLUMN     "opponentName" TEXT NOT NULL,
+ADD COLUMN     "playerDeck" TEXT[],
+ADD COLUMN     "playerName" TEXT NOT NULL,
+DROP COLUMN "win",
+ADD COLUMN     "win" INTEGER NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,11 +15,15 @@ datasource db {
 
 model battles {
   id            Int       @id @default(autoincrement())
-  battleTime    String  
+  battleTime    String
+  playerName    String  
   playerTag     String
-  opponentTag   String
+  playerDeck    String[]
   playerCrowns  Int
+  opponentName  String
+  opponentTag   String
+  opponentDeck  String[]
   opponentCrowns Int
-  clanId        String
-  win           Boolean
+  clanName      String
+  win           Int
 }

--- a/src/lib/helpers/funcs/clean-decks/clean-played-deck.spec.ts
+++ b/src/lib/helpers/funcs/clean-decks/clean-played-deck.spec.ts
@@ -1,0 +1,28 @@
+import cleanPlayerDeck from "./clean-player-deck";
+import { cards } from "./mock-data";
+
+describe("cleanPlayerDeck", () => {
+  // Test #1: Function should return an array of strings
+  it("should return an array of strings", () => {
+    const mockCards = cards;
+    const urls = cleanPlayerDeck(mockCards);
+    expect(Array.isArray(urls)).toBe(true);
+    expect(typeof urls[0]).toBe("string");
+  });
+
+  // Test #2: Should correctly extract medium icon URLs from the cards
+  it("should extract medium icon URLs", () => {
+    const mockCards = cards;
+    const urls = cleanPlayerDeck(mockCards);
+    expect(urls).toEqual([
+      "https://api-assets.clashroyale.com/cards/300/jAj1Q5rclXxU9kVImGqSJxa4wEMfEhvwNQ_4jiGUuqg.png",
+      "https://api-assets.clashroyale.com/cards/300/C88C5JH_F3lLZj6K-tLcMo5DPjrFmvzIb1R2M6xCfTE.png",
+    ]);
+  });
+
+  // Test #3: Should handle an empty array input
+  it("should handle an empty array", () => {
+    const urls = cleanPlayerDeck([]);
+    expect(urls).toEqual([]);
+  });
+});

--- a/src/lib/helpers/funcs/clean-decks/clean-player-deck.ts
+++ b/src/lib/helpers/funcs/clean-decks/clean-player-deck.ts
@@ -1,0 +1,7 @@
+import { Card } from "@/lib/types/types";
+
+const cleanPlayerDeck = (deck: Card[]): string[] => {
+  return deck.map((element) => element.iconUrls.medium);
+};
+
+export default cleanPlayerDeck;

--- a/src/lib/helpers/funcs/clean-decks/mock-data.ts
+++ b/src/lib/helpers/funcs/clean-decks/mock-data.ts
@@ -1,0 +1,25 @@
+export const cards = [
+  {
+    name: "Knight",
+    id: 26000000,
+    level: 11,
+    maxLevel: 14,
+    maxEvolutionLevel: 1,
+    iconUrls: {
+      medium:
+        "https://api-assets.clashroyale.com/cards/300/jAj1Q5rclXxU9kVImGqSJxa4wEMfEhvwNQ_4jiGUuqg.png",
+      evolutionMedium:
+        "https://api-assets.clashroyale.com/cardevolutions/300/jAj1Q5rclXxU9kVImGqSJxa4wEMfEhvwNQ_4jiGUuqg.png",
+    },
+  },
+  {
+    name: "Elite Barbarians",
+    id: 26000043,
+    level: 11,
+    maxLevel: 14,
+    iconUrls: {
+      medium:
+        "https://api-assets.clashroyale.com/cards/300/C88C5JH_F3lLZj6K-tLcMo5DPjrFmvzIb1R2M6xCfTE.png",
+    },
+  },
+];

--- a/src/lib/types/types.ts
+++ b/src/lib/types/types.ts
@@ -1,0 +1,84 @@
+export type Card = {
+  name: string;
+  id: number;
+  level: number;
+  starLevel?: number;
+  maxLevel: number;
+  maxEvolutionLevel?: number;
+  iconUrls: {
+    medium: string;
+    evolutionMedium?: string;
+  };
+};
+
+export type Clan = {
+  tag: string;
+  name: string;
+  badgeId: number;
+};
+
+export type Player = {
+  tag: string;
+  name: string;
+  startingTrophies: number;
+  trophyChange: number;
+  crowns: number;
+  kingTowerHitPoints: number;
+  princessTowersHitPoints?: number[] | null;
+  clan: Clan;
+  cards: Card[];
+  globalRank: null | number;
+  elixirLeaked: number;
+};
+
+export type GameMode = {
+  id: number;
+  name: string;
+};
+
+export type Arena = {
+  id: number;
+  name: string;
+};
+
+export type Battle = {
+  type: string;
+  battleTime: string;
+  isLadderTournament: boolean;
+  arena: Arena;
+  gameMode: GameMode;
+  deckSelection: string;
+  team: Player[];
+  opponent: Player[];
+  isHostedMatch: boolean;
+  leagueNumber: number;
+};
+
+// Define the type for an array of Battle objects
+export type Battles = Battle[];
+
+export type CleanedData = {
+  battleTime: string;
+  playerName: string;
+  playerTag: string;
+  playerDeck: string[];
+  playerCrowns: number;
+  opponentName: string;
+  opponentTag: string;
+  opponentDeck: string[];
+  opponentCrowns: number;
+  clanName: string;
+  //win = 2 means player has won
+  //win = 1 means opponent has won
+  //win = 0 means draw
+  win: number;
+};
+
+export type RoyaleApiResonse = {
+  foundBattles: boolean;
+  data: CleanedData[] | string;
+};
+
+export type RoyaleApiErrorResponse = {
+  message: string;
+};

--- a/src/pages/api/royale-api.ts
+++ b/src/pages/api/royale-api.ts
@@ -1,0 +1,79 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import axios from "axios";
+import {
+  Battles,
+  CleanedData,
+  RoyaleApiResonse,
+  RoyaleApiErrorResponse,
+} from "@/lib/types/types";
+import cleanPlayerDeck from "@/lib/helpers/funcs/clean-decks/clean-player-deck";
+
+const URL = "https://proxy.royaleapi.dev/v1/players/%23LGP89JU/battlelog";
+const headers = {
+  Accept: "application/json",
+  Authorization: `Bearer ${process.env.ROYALE_API_KEY}`,
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<RoyaleApiResonse | RoyaleApiErrorResponse>
+) {
+  try {
+    const response = await axios.get<Battles>(URL, { headers });
+    const friendlyBattles = response.data.filter(
+      (item) => item.type === "clanMate"
+    );
+
+    if (!friendlyBattles)
+      res.status(404).json({
+        foundBattles: false,
+        data: "Oops. Looks like you havent had any friendly battles recently. Why dont you have some and come back!",
+      });
+
+    const cleanedFriendlyBattles: CleanedData[] = friendlyBattles.map(
+      (battle) => {
+        const { battleTime, team, opponent } = battle;
+        const {
+          name: playerName,
+          tag: playerTag,
+          crowns: playerCrowns,
+          cards: playerCards,
+          clan,
+        } = team[0];
+        const {
+          name: opponentName,
+          tag: opponentTag,
+          crowns: opponentCrowns,
+          cards: opponentCards,
+        } = opponent[0];
+        const { name: clanName } = clan;
+        let win = 0;
+
+        const playerDeck: string[] = cleanPlayerDeck(playerCards);
+        const opponentDeck: string[] = cleanPlayerDeck(opponentCards);
+
+        if (playerCrowns > opponentCrowns) win = 2;
+        else if (playerCrowns < opponentCrowns) win = 1;
+
+        return {
+          battleTime: battleTime,
+          playerName: playerName,
+          playerTag: playerTag,
+          playerDeck: playerDeck,
+          playerCrowns: playerCrowns,
+          opponentName: opponentName,
+          opponentTag: opponentTag,
+          opponentDeck: opponentDeck,
+          opponentCrowns: opponentCrowns,
+          clanName: clanName,
+          win: win,
+        };
+      }
+    );
+
+    res.status(200).json({ foundBattles: true, data: cleanedFriendlyBattles });
+  } catch (error) {
+    console.log({ message: error });
+    res.status(500);
+  }
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,7 +7,7 @@ const IndexPage = () => {
     // Fetching data from the API endpoint
     const fetchData = async () => {
       try {
-        const response = await axios.get("/api/battles");
+        const response = await axios.get("/api/royale-api");
         setBattles(response.data);
       } catch (error) {
         console.log(error);


### PR DESCRIPTION
in this PR: 

- a new API endpoint (/api/royale-api) was made to hit the clash royale api and get users battlelog. This is then cleaned and returned as a response. 
- tests have been written for the function cleanPlayerDeck