### PR TITLE
feat: Dynamic player tag api

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-DATABASE_URL = postgresql://postgres:Xh*rB+kj9RdepE5@db.fkdsoecckvzuouwxffhp.supabase.co:5432/postgres

--- a/src/pages/api/royale-api.ts
+++ b/src/pages/api/royale-api.ts
@@ -8,23 +8,23 @@ import {
 } from "@/lib/types/types";
 import cleanPlayerDeck from "@/lib/helpers/funcs/clean-decks/clean-player-deck";
 
-const URL = "https://proxy.royaleapi.dev/v1/players/%23LGP89JU/battlelog";
-const headers = {
-  Accept: "application/json",
-  Authorization: `Bearer ${process.env.ROYALE_API_KEY}`,
-};
-
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<RoyaleApiResonse | RoyaleApiErrorResponse>
 ) {
+  const playerTag = req.query.playerTag;
+  const URL = `https://proxy.royaleapi.dev/v1/players/%23${playerTag}/battlelog`;
+  const headers = {
+    Accept: "application/json",
+    Authorization: `Bearer ${process.env.ROYALE_API_KEY}`,
+  };
   try {
     const response = await axios.get<Battles>(URL, { headers });
     const friendlyBattles = response.data.filter(
-      (item) => item.type === "clanMate"
+      (item) => item.type === "clanMate" || item.type === "friendly"
     );
 
-    if (!friendlyBattles)
+    if (friendlyBattles.length === 0)
       res.status(404).json({
         foundBattles: false,
         data: "Oops. Looks like you havent had any friendly battles recently. Why dont you have some and come back!",

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,7 +7,7 @@ const IndexPage = () => {
     // Fetching data from the API endpoint
     const fetchData = async () => {
       try {
-        const response = await axios.get("/api/royale-api");
+        const response = await axios.get("/api/royale-api?playerTag=CRL0QQQ9C");
         setBattles(response.data);
       } catch (error) {
         console.log(error);


### PR DESCRIPTION
In this commit:

- The clashroyale API endpoint is dynamic so it returns data for whatever user is passed in on the front end (currently this is just done through hardcoding the url on the front end)

- not just clan battles are shown now, friendly battles are also included