### PR TITLE
feat: Update db table name and types

### DIFF
--- a/prisma/dbml/schema.dbml
+++ b/prisma/dbml/schema.dbml
@@ -2,7 +2,7 @@
 //// THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)
 //// ------------------------------------------------------
 
-Table battles {
+Table UsersBattles {
   id Int [pk, increment]
   battleTime String [not null]
   playerName String [not null]

--- a/prisma/migrations/20231125173732_update_table_name/migration.sql
+++ b/prisma/migrations/20231125173732_update_table_name/migration.sql
@@ -1,0 +1,26 @@
+/*
+  Warnings:
+
+  - You are about to drop the `battles` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropTable
+DROP TABLE "battles";
+
+-- CreateTable
+CREATE TABLE "UsersBattles" (
+    "id" SERIAL NOT NULL,
+    "battleTime" TEXT NOT NULL,
+    "playerName" TEXT NOT NULL,
+    "playerTag" TEXT NOT NULL,
+    "playerDeck" TEXT[],
+    "playerCrowns" INTEGER NOT NULL,
+    "opponentName" TEXT NOT NULL,
+    "opponentTag" TEXT NOT NULL,
+    "opponentDeck" TEXT[],
+    "opponentCrowns" INTEGER NOT NULL,
+    "clanName" TEXT NOT NULL,
+    "win" INTEGER NOT NULL,
+
+    CONSTRAINT "UsersBattles_pkey" PRIMARY KEY ("id")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,19 +11,17 @@ datasource db {
     url      = env("DATABASE_URL") // uses connection pooling
 }
 
-
-
-model battles {
-  id            Int       @id @default(autoincrement())
-  battleTime    String
-  playerName    String  
-  playerTag     String
-  playerDeck    String[]
-  playerCrowns  Int
-  opponentName  String
-  opponentTag   String
-  opponentDeck  String[]
-  opponentCrowns Int
-  clanName      String
-  win           Int
+model UsersBattles {
+    id             Int      @id @default(autoincrement())
+    battleTime     String
+    playerName     String
+    playerTag      String
+    playerDeck     String[]
+    playerCrowns   Int
+    opponentName   String
+    opponentTag    String
+    opponentDeck   String[]
+    opponentCrowns Int
+    clanName       String
+    win            Int
 }

--- a/src/lib/helpers/form-battles-summaries/form-battle-summaries.ts
+++ b/src/lib/helpers/form-battles-summaries/form-battle-summaries.ts
@@ -1,9 +1,9 @@
 import { BattleSummaries } from "@/lib/types/battle-summaries-types";
-import { DbRow } from "@/lib/types/db-types";
+import { UsersBattles } from "@prisma/client";
 import { CleanedData } from "@/lib/types/royale-api-types";
 
 const formBattlesSummaries = (
-  battles: DbRow[] | CleanedData[]
+  battles: UsersBattles[] | CleanedData[]
 ): BattleSummaries => {
   const resultMap = new Map();
 

--- a/src/lib/helpers/update-db-api-logic/get-recent-db-rows.ts
+++ b/src/lib/helpers/update-db-api-logic/get-recent-db-rows.ts
@@ -1,14 +1,14 @@
 import { handleError } from "@/lib/helpers/handle-error/handle-error";
 import prisma from "@/lib/prisma-client";
-import { DbRow } from "@/lib/types/db-types";
+import { UsersBattles } from "@prisma/client";
 
 export async function getRecentDbRows(
   playerTag: string | string[] | undefined
-): Promise<DbRow[]> {
+): Promise<UsersBattles[]> {
   try {
     console.log("Before querying the database"); // Log before the query
 
-    const battles = await prisma.battles.findMany({
+    const battles = await prisma.usersBattles.findMany({
       where: {
         playerTag: `#${playerTag}`,
       },

--- a/src/lib/helpers/update-db-api-logic/insert-db-rows.ts
+++ b/src/lib/helpers/update-db-api-logic/insert-db-rows.ts
@@ -5,7 +5,7 @@ import { CleanedData } from "@/lib/types/royale-api-types";
 export async function insertDbRows(friendlyBattles: CleanedData[]) {
   console.log("insert db rows func");
   try {
-    const result = await prisma.battles.createMany({
+    const result = await prisma.usersBattles.createMany({
       data: friendlyBattles,
     });
     return result;

--- a/src/lib/types/battle-summaries-types.ts
+++ b/src/lib/types/battle-summaries-types.ts
@@ -1,11 +1,11 @@
-import { DbRow } from "./db-types";
-
+import { UsersBattles } from "@prisma/client";
 export type BattleSummary = {
   playerName: string;
+
   opponentName: string;
   playerWins: number;
   opponentWins: number;
-  battles: DbRow[];
+  battles: UsersBattles[];
 };
 
 export type BattleSummaries = BattleSummary[];

--- a/src/lib/types/db-types.ts
+++ b/src/lib/types/db-types.ts
@@ -1,21 +1,7 @@
 import { CleanedData } from "./royale-api-types";
-
-export type DbRow = {
-  id: number;
-  battleTime: string;
-  playerName: string;
-  playerTag: string;
-  playerDeck: string[];
-  playerCrowns: number;
-  opponentName: string;
-  opponentTag: string;
-  opponentDeck: string[];
-  opponentCrowns: number;
-  clanName: string;
-  win: number;
-};
+import { UsersBattles } from "@prisma/client";
 
 export type UpdateDbResponse = {
   rowsAdded?: number;
-  battles?: DbRow[] | CleanedData[];
+  battles?: UsersBattles[] | CleanedData[];
 };


### PR DESCRIPTION
In this PR:

- The table name was changed from battles to UsersBattles. This is so that when using the prisma types correct TS best practice is followed.
- When reading from the table and inserting to it battles was changed to usersBattles
- Now that the prisma type is being used the type of DbRow is not needed so this was replaced and deleted