### PR TITLE
feat: create tailwindcss component for row addition alert

### DIFF
--- a/src/components/battle-summaries.tsx
+++ b/src/components/battle-summaries.tsx
@@ -12,6 +12,7 @@ const BattleSummaries = () => {
         key={i}
         className="px-8 py-2 flex flex-col items-center border rounded w-full"
       >
+        <p className="font-bold text-xs">Overall Record</p>
         <div className="grid grid-cols-[1fr_40px_1fr] gap-4 items-center w-full">
           <div className="flex flex-col items-end justify-center">
             <p className={crownsRowStyle}>{summary.playerWins}</p>

--- a/src/components/row-insert-popup.tsx
+++ b/src/components/row-insert-popup.tsx
@@ -1,0 +1,23 @@
+import { useGlobalState } from "@/lib/contexts/global-context";
+import React from "react";
+
+const RowInsertPopup: React.FC = () => {
+  const { battles } = useGlobalState();
+  return battles?.rowsAdded === "NA" ? (
+    <div className="w-full p-4 border border-2 border-red-400 bg-red-200 text-red-600 rounded mb-6">
+      <p>
+        Opps. Looks like you dont have any battles with friends yet. Go and have
+        some battles then come back
+      </p>
+    </div>
+  ) : (
+    <div className="w-full p-4 border border-2 border-green-400 bg-green-200 text-green-600 rounded mb-6">
+      <p>
+        Inserted {battles?.rowsAdded} battles to the DB. Please hit refresh to
+        see them
+      </p>
+    </div>
+  );
+};
+
+export default RowInsertPopup;

--- a/src/components/search-bar.tsx
+++ b/src/components/search-bar.tsx
@@ -5,7 +5,8 @@ import { cleanUserTag } from "@/lib/helpers/clean-user-tag/clean-user-tag";
 
 const SearchBar: React.FC = ({}) => {
   const [searchTerm, setSearchTerm] = useState("");
-  const { setPlayerData, setBattles, setError } = useGlobalState();
+  const { setPlayerData, setBattles, setError, setPlayerTag } =
+    useGlobalState();
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     setSearchTerm(event.target.value);
@@ -14,6 +15,7 @@ const SearchBar: React.FC = ({}) => {
   const fetchData = async (playerTag: string) => {
     try {
       let tag = cleanUserTag(playerTag);
+      setPlayerTag(tag);
       const playerData = await axios.get(`/api/get-user-data?playerTag=${tag}`);
       setPlayerData(playerData.data.body);
       const response = await axios.get(`/api/update-db?playerTag=${tag}`);

--- a/src/components/show-data.tsx
+++ b/src/components/show-data.tsx
@@ -1,12 +1,14 @@
 import { useGlobalState } from "@/lib/contexts/global-context";
 import ShowPlayerData from "./show-player-data";
 import ShowPlayerBattles from "./show-battle-data";
+import RowInsertPopup from "./row-insert-popup";
 
 const ShowData: React.FC = () => {
   const { playerData, battles } = useGlobalState();
 
   return (
     <>
+      {battles?.rowsAdded && <RowInsertPopup />}
       {!playerData && <p>Get started and search a user</p>}
       {playerData && <ShowPlayerData />}
       {battles?.battles && <ShowPlayerBattles />}

--- a/src/components/show-player-data.tsx
+++ b/src/components/show-player-data.tsx
@@ -1,8 +1,26 @@
 import { useGlobalState } from "@/lib/contexts/global-context";
+import axios from "axios";
 import Image from "next/image";
 
 const ShowPlayerData: React.FC = () => {
-  const { playerData } = useGlobalState();
+  const { playerData, playerTag, setBattles, setError, battles } =
+    useGlobalState();
+
+  const refreshData = async () => {
+    try {
+      setBattles({});
+      const response = await axios.get(`/api/update-db?playerTag=${playerTag}`);
+      setBattles(response.data.body);
+      setError("");
+    } catch (error) {
+      if (axios.isAxiosError(error)) {
+        console.log(error);
+        setError(error.response?.data.error);
+      } else {
+        setError({ message: "something went wrong" });
+      }
+    }
+  };
   return (
     <div className="border rounded p-4">
       <div className="flex justify-between items-center mb-2">
@@ -17,6 +35,14 @@ const ShowPlayerData: React.FC = () => {
           <Image src={"/trophy.svg"} alt="trophies" width={24} height={24} />
           <p className="text-gray-600">{playerData?.trophies}</p>
         </div>
+      </div>
+      <div className="w-full flex justify-center border-t pt-4 mt-4">
+        <button
+          className="text-blue-400 font-bold w-full"
+          onClick={refreshData}
+        >
+          Refresh Player Data
+        </button>
       </div>
     </div>
   );

--- a/src/lib/contexts/global-context.tsx
+++ b/src/lib/contexts/global-context.tsx
@@ -18,6 +18,8 @@ interface GlobalState {
   setPlayerData: (value: CleanedUserData | undefined) => void;
   battleSummaries: BattleSummary[] | undefined;
   setBattleSummaries: (value: BattleSummary[] | undefined) => void;
+  playerTag: string;
+  setPlayerTag: (value: string) => void;
 }
 
 // Create a context with a default value
@@ -33,6 +35,7 @@ export const GlobalStateProvider: React.FC<GlobalStateContextProps> = ({
   const [error, setError] = useState<APIError | string | undefined>(); // State to store the error message
   const [playerData, setPlayerData] = useState<CleanedUserData | undefined>();
   const [battleSummaries, setBattleSummaries] = useState<BattleSummary[]>();
+  const [playerTag, setPlayerTag] = useState<string>("");
 
   const contextValue: GlobalState = {
     battles,
@@ -43,6 +46,8 @@ export const GlobalStateProvider: React.FC<GlobalStateContextProps> = ({
     setPlayerData,
     battleSummaries,
     setBattleSummaries,
+    playerTag,
+    setPlayerTag,
   };
 
   return (

--- a/src/lib/helpers/update-db-api-logic/update-db-api-logic.spec.ts
+++ b/src/lib/helpers/update-db-api-logic/update-db-api-logic.spec.ts
@@ -27,7 +27,7 @@ describe("api logic for updating db", () => {
     mockedGetRecentDbRows.mockResolvedValue(testData.testOneDbMockReturn);
 
     const result = await apiLogic("string");
-    expect(result).toEqual({});
+    expect(result).toEqual({ rowsAdded: "NA" });
   });
 
   it("should returns database battles only when API battles are absent but database battles exist)", async () => {

--- a/src/lib/helpers/update-db-api-logic/update-db-api-logic.ts
+++ b/src/lib/helpers/update-db-api-logic/update-db-api-logic.ts
@@ -10,12 +10,12 @@ const apiLogic = async (playerTag: string | string[] | undefined) => {
 
     //If no api battles or database battles are found then the user should be told to first play some battles on the front end
     if (apiBattles.length === 0 && allDbBattles.length === 0) {
-      return {};
+      return { rowsAdded: "NA" };
     } else if (apiBattles.length === 0 && allDbBattles.length > 0) {
       return { battles: allDbBattles };
     } else if (apiBattles.length > 0 && allDbBattles.length === 0) {
       await insertDbRows(apiBattles);
-      return { rowsAdded: apiBattles.length, battles: apiBattles };
+      return { rowsAdded: apiBattles.length };
     }
 
     const mostRecentBattleTime = allDbBattles[0].battleTime;

--- a/src/lib/types/db-types.ts
+++ b/src/lib/types/db-types.ts
@@ -2,6 +2,6 @@ import { CleanedData } from "./royale-api-types";
 import { UsersBattles } from "@prisma/client";
 
 export type UpdateDbResponse = {
-  rowsAdded?: number;
+  rowsAdded?: number | string;
   battles?: UsersBattles[] | CleanedData[];
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,7 +6,7 @@ import { useGlobalState } from "@/lib/contexts/global-context";
 const IndexPage = () => {
   const { error } = useGlobalState();
   return (
-    <div className="w-full bg-red-300 md:bg-blue-300 lg:bg-green-300">
+    <div className="w-full ">
       <NavBar />
       <div className={`px-4 md:px-24 lg:px-48 xl:px-96 2xl:px-[30rem] py-8`}>
         {/* <button onClick={fetchData} className="bg-white text-black">


### PR DESCRIPTION
In this PR:

- A component to tell the user how many rows were added to the DB was made
- a button to refresh player battles was added to the bottom of the players data
- player tag was stored in context so that it could be used to refresh players battles data when the button in the above point was clicked
- rowsAdded was given the additional type of string. This is so that when no battles are found {rowsAdded: "NA" } can be returned and handled on the front end