### PR TITLE
feat: button to toggle visibility of battles

### DIFF
--- a/src/components/battle-summaries.tsx
+++ b/src/components/battle-summaries.tsx
@@ -1,35 +1,11 @@
 import { useGlobalState } from "@/lib/contexts/global-context";
 import IndividualBattles from "./individual-battles";
+import IndividiualSummaries from "./individual-summaries";
 
 const BattleSummaries = () => {
   const { battleSummaries } = useGlobalState();
-  const crownsRowStyle = "text-xl lg:text-3xl";
-  const playersNamesRowStyle = "text-2xl font-bold lg:text-4xl";
-
   return battleSummaries?.map((summary, i) => {
-    return (
-      <div
-        key={i}
-        className="px-8 py-2 flex flex-col items-center border rounded w-full"
-      >
-        <p className="font-bold text-xs">Overall Record</p>
-        <div className="grid grid-cols-[1fr_40px_1fr] gap-4 items-center w-full">
-          <div className="flex flex-col items-end justify-center">
-            <p className={crownsRowStyle}>{summary.playerWins}</p>
-            <p className={playersNamesRowStyle}>{summary.playerName}</p>
-          </div>
-          <div className="flex flex-col items-center justify-center">
-            <p className={crownsRowStyle}>-</p>
-            <p className={playersNamesRowStyle}>VS</p>
-          </div>
-          <div className="flex flex-col items-start justify-center">
-            <p className={crownsRowStyle}>{summary.opponentWins}</p>
-            <p className={playersNamesRowStyle}>{summary.opponentName}</p>
-          </div>
-        </div>
-        <IndividualBattles individualBattles={summary.battles} />
-      </div>
-    );
+    return <IndividiualSummaries key={i} summary={summary} />;
   });
 };
 

--- a/src/components/individual-summaries.tsx
+++ b/src/components/individual-summaries.tsx
@@ -1,0 +1,39 @@
+import { BattleSummary } from "@/lib/types/battle-summaries-types";
+import React from "react";
+import { useState } from "react";
+import IndividualBattles from "./individual-battles";
+
+interface ComponentProps {
+  summary: BattleSummary;
+}
+
+const IndividiualSummaries: React.FC<ComponentProps> = ({ summary }) => {
+  const crownsRowStyle = "text-xl lg:text-3xl";
+  const playersNamesRowStyle = "text-2xl font-bold lg:text-4xl";
+  const [showBattles, setShowBattles] = useState(false);
+  return (
+    <div className="px-8 py-2 flex flex-col items-center border rounded w-full">
+      <p className="font-bold text-xs">Overall Record</p>
+      <div className="grid grid-cols-[1fr_40px_1fr] gap-4 items-center w-full">
+        <div className="flex flex-col items-end justify-center">
+          <p className={crownsRowStyle}>{summary.playerWins}</p>
+          <p className={playersNamesRowStyle}>{summary.playerName}</p>
+        </div>
+        <div className="flex flex-col items-center justify-center">
+          <p className={crownsRowStyle}>-</p>
+          <p className={playersNamesRowStyle}>VS</p>
+        </div>
+        <div className="flex flex-col items-start justify-center">
+          <p className={crownsRowStyle}>{summary.opponentWins}</p>
+          <p className={playersNamesRowStyle}>{summary.opponentName}</p>
+        </div>
+      </div>
+      <button onClick={() => setShowBattles(!showBattles)}>
+        {!showBattles ? <p>Show Battles</p> : <p>Hide Battles</p>}
+      </button>
+      {showBattles && <IndividualBattles individualBattles={summary.battles} />}
+    </div>
+  );
+};
+
+export default IndividiualSummaries;


### PR DESCRIPTION
In this PR:

- All of the html for battle summaries was moved to another component to allow state for each individual summary to be tracked
- A button was made to toggle the visibility of all battles within a summary